### PR TITLE
Start game script

### DIFF
--- a/Assets/Scenes/Levels/Level1.unity
+++ b/Assets/Scenes/Levels/Level1.unity
@@ -131,6 +131,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 1322231045}
     m_Modifications:
     - target: {fileID: 7842074604623804345, guid: fd8856453c77d05408f657cad9045cb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7842074604623804345, guid: fd8856453c77d05408f657cad9045cb5, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1155593130}
@@ -553,6 +557,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: NextLevelButton
       objectReference: {fileID: 0}
+    - target: {fileID: 216700664854890637, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: sceneID
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 492018615450734594, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
       propertyPath: m_Name
       value: GameManager
@@ -617,6 +625,14 @@ PrefabInstance:
       propertyPath: ShootButton
       value: 
       objectReference: {fileID: 1438842515}
+    - target: {fileID: 2945626929414467432, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5082016721459183344, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5082016721459183344, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_IntArgument
       value: 2
@@ -637,8 +653,48 @@ PrefabInstance:
       propertyPath: m_Name
       value: GoToShopButton
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 8454818900265337698, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8454818900265337698, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 176178388}
+    - target: {fileID: 8454818900265337698, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnClick
+      objectReference: {fileID: 0}
+    - target: {fileID: 8454818900265337698, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: MoveToNextLevel, Assembly-CSharp
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 7989112651247198434, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+--- !u!1 &176178386 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 492018615450734594, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+  m_PrefabInstance: {fileID: 176178385}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &176178387 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 85652148626185917, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+  m_PrefabInstance: {fileID: 176178385}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &176178388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 176178387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8631dff185684814089afab92601ea28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nextSceneLoad: 0
 --- !u!1001 &230915498
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1134,7 +1190,7 @@ MonoBehaviour:
       - m_Target: {fileID: 767891518}
         m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
         m_MethodName: MoveToScene
-        m_Mode: 3
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1193,6 +1249,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e8acfaadc0327964985161b43fa74fa1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneID: 0
 --- !u!224 &776958497 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 94011132995462483, guid: d5f4a354c943c1141903379f80197014, type: 3}
@@ -1505,12 +1562,25 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 492018615450734605, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
   m_PrefabInstance: {fileID: 176178385}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 176178386}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e0d063ba08a8ae4591430f24c398760, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1155593131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 176178386}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6b4e01533543294b816ed24270fdad4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  finalLevelIndex: 4
 --- !u!224 &1322231045 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1671602530665182867, guid: a2ea35aa98eeff749902bfcde9028a51, type: 3}
@@ -2364,6 +2434,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e8acfaadc0327964985161b43fa74fa1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneID: 2
 --- !u!114 &2143325033
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2411,7 +2482,7 @@ MonoBehaviour:
       - m_Target: {fileID: 2143325032}
         m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
         m_MethodName: MoveToScene
-        m_Mode: 3
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Scenes/Levels/Level2.unity
+++ b/Assets/Scenes/Levels/Level2.unity
@@ -131,6 +131,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 1322231045}
     m_Modifications:
     - target: {fileID: 7842074604623804345, guid: fd8856453c77d05408f657cad9045cb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7842074604623804345, guid: fd8856453c77d05408f657cad9045cb5, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1155593130}
@@ -549,6 +553,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 216700664854890637, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: sceneID
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 492018615450734594, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
       propertyPath: m_Name
       value: GameManager
@@ -613,12 +621,55 @@ PrefabInstance:
       propertyPath: ShootButton
       value: 
       objectReference: {fileID: 1438842515}
+    - target: {fileID: 2945626929414467432, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5082016721459183344, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5159724522841172093, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
       propertyPath: m_Camera
       value: 
       objectReference: {fileID: 475604575}
-    m_RemovedComponents: []
+    - target: {fileID: 8454818900265337698, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8454818900265337698, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 176178387}
+    - target: {fileID: 8454818900265337698, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnClick
+      objectReference: {fileID: 0}
+    - target: {fileID: 8454818900265337698, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: MoveToNextLevel, Assembly-CSharp
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 7989112651247198434, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+--- !u!1 &176178386 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 85652148626185917, guid: 7f871258ab2e6044fa14833a3ee6ec87, type: 3}
+  m_PrefabInstance: {fileID: 176178385}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &176178387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 176178386}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8631dff185684814089afab92601ea28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nextSceneLoad: 0
 --- !u!1001 &230915498
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1114,7 +1165,7 @@ MonoBehaviour:
       - m_Target: {fileID: 767891518}
         m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
         m_MethodName: MoveToScene
-        m_Mode: 3
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1173,6 +1224,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e8acfaadc0327964985161b43fa74fa1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneID: 0
 --- !u!224 &776958497 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 94011132995462483, guid: d5f4a354c943c1141903379f80197014, type: 3}
@@ -2355,6 +2407,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e8acfaadc0327964985161b43fa74fa1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneID: 2
 --- !u!114 &2143325033
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2402,7 +2455,7 @@ MonoBehaviour:
       - m_Target: {fileID: 2143325032}
         m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
         m_MethodName: MoveToScene
-        m_Mode: 3
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Scenes/Menus/LevelSelect.unity
+++ b/Assets/Scenes/Menus/LevelSelect.unity
@@ -306,11 +306,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1199163879817861000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1953608090421815872, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4818020249803037220, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: m_Pivot.x
@@ -426,7 +426,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8366034637556335251, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
@@ -857,11 +857,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1199163879817861000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1953608090421815872, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4818020249803037220, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: m_Pivot.x
@@ -977,7 +977,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8366034637556335251, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
@@ -1127,7 +1127,7 @@ MonoBehaviour:
   - {fileID: 2127156894}
   - {fileID: 1701867404}
   - {fileID: 2082004815}
-  firstLevelIndex: 2
+  firstLevelIndex: 3
 --- !u!4 &1309752905
 Transform:
   m_ObjectHideFlags: 0
@@ -1539,11 +1539,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1199163879817861000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1953608090421815872, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4818020249803037220, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: m_Pivot.x
@@ -1659,7 +1659,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8366034637556335251, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
@@ -1767,11 +1767,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1199163879817861000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1953608090421815872, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 4818020249803037220, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: m_Pivot.x
@@ -1887,7 +1887,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8366034637556335251, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
@@ -1927,11 +1927,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1199163879817861000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1953608090421815872, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4818020249803037220, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: m_Pivot.x
@@ -2047,7 +2047,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8366034637556335251, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}
       propertyPath: sceneID
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e05c7864efafdd4fbda032ef0660ee8, type: 3}

--- a/Assets/Scenes/Menus/MainMenu.unity
+++ b/Assets/Scenes/Menus/MainMenu.unity
@@ -257,6 +257,66 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 159698681}
   m_CullTransparentMesh: 1
+--- !u!1 &283249121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 283249124}
+  - component: {fileID: 283249123}
+  - component: {fileID: 283249122}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &283249122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 283249121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eda368bf6ec350f4b8e8f51b97ec384e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  levelButtons: []
+  firstLevelIndex: 3
+--- !u!114 &283249123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 283249121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6b4e01533543294b816ed24270fdad4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  finalLevelIndex: 4
+--- !u!4 &283249124
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 283249121}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.44131172, y: 23.802664, z: -11.098869}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &409931422
 GameObject:
   m_ObjectHideFlags: 0
@@ -1880,8 +1940,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2059960856}
-        m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
-        m_MethodName: MoveToScene
+        m_TargetAssemblyTypeName: StartGame, Assembly-CSharp
+        m_MethodName: BeginGame
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1938,10 +1998,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 2059960851}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e8acfaadc0327964985161b43fa74fa1, type: 3}
+  m_Script: {fileID: 11500000, guid: fa4144009e685b94f8d708f16960cf54, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sceneID: 2
 --- !u!1001 &1323526766333946412
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2164,14 +2223,6 @@ PrefabInstance:
     - target: {fileID: 8458213958768342719, guid: 28076d6b52d6a78428bc6f0aa2acdfbf, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8783214971241623824, guid: 28076d6b52d6a78428bc6f0aa2acdfbf, type: 3}
-      propertyPath: m_MinValue
-      value: 0.0001
-      objectReference: {fileID: 0}
-    - target: {fileID: 1481073455857401214, guid: 28076d6b52d6a78428bc6f0aa2acdfbf, type: 3}
-      propertyPath: m_MinValue
-      value: 0.0001
       objectReference: {fileID: 0}
     - target: {fileID: 8783214971241623824, guid: 28076d6b52d6a78428bc6f0aa2acdfbf, type: 3}
       propertyPath: m_MinValue

--- a/Assets/Scenes/Menus/Shop.unity
+++ b/Assets/Scenes/Menus/Shop.unity
@@ -1017,6 +1017,7 @@ GameObject:
   - component: {fileID: 767427742}
   - component: {fileID: 767427741}
   - component: {fileID: 767427740}
+  - component: {fileID: 767427743}
   m_Layer: 0
   m_Name: ExitButton
   m_TagString: Untagged
@@ -1088,7 +1089,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 767427741}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 767427743}
+        m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
+        m_MethodName: MoveToScene
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &767427741
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1127,6 +1140,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 767427738}
   m_CullTransparentMesh: 1
+--- !u!114 &767427743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 767427738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e8acfaadc0327964985161b43fa74fa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneID: 0
 --- !u!1 &775322493
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameScripts/StartGame.cs
+++ b/Assets/Scripts/GameScripts/StartGame.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class StartGame : MonoBehaviour
+{
+    
+    public void BeginGame()
+    {
+        int sceneID = PlayerPrefs.GetInt("firstLevelIndex");
+        Debug.Log("Scene ID is: " + sceneID);
+        // sceneID = PlayerPrefs.GetInt(levelName);
+        Scene nextScene = SceneManager.GetSceneByBuildIndex(sceneID);
+        SceneManager.LoadScene(sceneID); 
+        StartCoroutine(SetActive(nextScene));
+    }
+    
+    public IEnumerator SetActive(Scene scene)
+    {
+        int i = 0;
+        while(i == 0)
+        {
+            i++;
+            yield return null;
+        }
+        SceneManager.SetActiveScene(scene);
+        yield break;
+    }
+}

--- a/Assets/Scripts/GameScripts/StartGame.cs.meta
+++ b/Assets/Scripts/GameScripts/StartGame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa4144009e685b94f8d708f16960cf54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Created a script that should allow the start game button to change scenes to level 1 without having to directly give it the proper index number. The LevelSelection script that's attached to either the GameManager or LevelManager objects, depending on the scene, now designates a user determined level as the starting level.